### PR TITLE
Fix Tooltips

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
         <input name="ssid" id="ssid" required/><br/>
         
         <label for="hidden">Hidden:</label>
-        <input type="checkbox" name="hidden" id="hidden" class="tooltip" data-tooltip="Is your SSID hidden?"/>
+        <span  class="tooltip" data-tooltip="Is your SSID hidden?"><input type="checkbox" name="hidden" id="hidden"/></span>
         </p>
         <p>
         <label for="enc">Encryption:</label><br/>
@@ -43,7 +43,7 @@
         <input name="key" id="key" type="password" required/><br/>
 
         <label for="display-key">display key:</label>
-        <input type="checkbox" name="display-key" id="display-key" class="tooltip" data-tooltip="Should the key be displayed in plain-text here? The QR code will always contain the key in plain-text!" />
+        <span class="tooltip" data-tooltip="Should the key be displayed in plain-text here? The QR code will always contain the key in plain-text!"><input type="checkbox" name="display-key" id="display-key"/></span>
         </p>
         <p>
         <button id="generate">Generate!</button>

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
         <input name="ssid" id="ssid" required/><br/>
         
         <label for="hidden">Hidden:</label>
-        <input type="checkbox" name="hidden" id="hidden" />
+        <input type="checkbox" name="hidden" id="hidden" class="tooltip" data-tooltip="Is your SSID hidden?"/>
         </p>
         <p>
         <label for="enc">Encryption:</label><br/>
@@ -43,7 +43,7 @@
         <input name="key" id="key" type="password" required/><br/>
 
         <label for="display-key">display key:</label>
-        <input type="checkbox" name="display-key" id="display-key" />
+        <input type="checkbox" name="display-key" id="display-key" class="tooltip" data-tooltip="Should the key be displayed in plain-text here? The QR code will always contain the key in plain-text!" />
         </p>
         <p>
         <button id="generate">Generate!</button>

--- a/style.css
+++ b/style.css
@@ -54,6 +54,7 @@ button {
     padding: 0em 0.75em;
     line-height: 200%;
     opacity: 0;
+    border-radius: 6px;
 }
 
 .tooltip:hover::before {

--- a/style.css
+++ b/style.css
@@ -37,3 +37,26 @@ button {
     border-radius: 6px;
     padding: 3px;
 }
+
+.tooltip {
+    position: relative;
+}
+
+.tooltip::before {
+    content: attr(data-tooltip);
+    font-size: 80%;
+    position: absolute;
+    z-index: 999;
+    white-space: nowrap;
+    left: 50%;
+    background: #000;
+    color: #e0e0e0;
+    padding: 0em 0.75em;
+    line-height: 200%;
+    opacity: 0;
+}
+
+.tooltip:hover::before {
+    opacity: 1;
+    bottom: -3em;
+}


### PR DESCRIPTION
The W3C Standard says that :after and :before can only be used on containers. Chrome seems to ignore that and supports them on every element
