### PR TITLE
git command typo correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Expat/MIT License. See the `LICENSE` file for details.
 Installation
 ------------
 1. `git clone https://github.com/evgeni/qifi.git`
-1. `git submodules init`
-1. `git submodules update`
+1. `git submodule init`
+1. `git submodule update`
 
 Configuration
 -------------


### PR DESCRIPTION
submodules -> submodule

```
% git submodules init
git: 'submodules' is not a git command. See 'git --help'.

Did you mean this?
        submodule
```
