### PR TITLE
Add word-wrap in printview for ssid and passphrase

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,7 +100,7 @@
         </div>
     </form>
     <h1 id="showssid">SSID: none</h1>
-    <h1 id="showkey">WPA: none</h1>
+    <h1 id="showkey">Passphrase: none</h1>
     <div id="qrcode"></div>
     </section>
     <section id="about">
@@ -187,7 +187,7 @@
             var enc = $('#enc').val();
             if (enc != 'nopass') {
                 var key = $('#key').val();
-                $('#showkey').text(enc+': '+key);
+                $('#showkey').text(enc+' Passphrase: '+key);
             } else {
                 var key = '';
                 $('#showkey').text('');

--- a/print.css
+++ b/print.css
@@ -13,4 +13,5 @@
 #showssid,
 #showkey {
     display: block;
+    word-wrap: break-word; 
 }


### PR DESCRIPTION
Long ssid/passphrase is not readable in printview.