### PR TITLE
Generate quiet zone around qr code borders for better scanning

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "jquery-qrcode"]
 	path = jquery-qrcode
-	url = https://github.com/jeromeetienne/jquery-qrcode.git
+	url = https://github.com/lrsjng/jquery-qrcode.git
 [submodule "github-fork-ribbon-css"]
 	path = github-fork-ribbon-css
 	url = https://github.com/simonwhitaker/github-fork-ribbon-css.git

--- a/index.html
+++ b/index.html
@@ -160,7 +160,7 @@
     </footer>
     <script src="jquery/jquery-3.3.1.min.js"></script>
     <script src="bootstrap/dist/js/bootstrap.min.js"></script>
-    <script src="jquery-qrcode/jquery.qrcode.min.js"></script>
+    <script src="jquery-qrcode/dist/jquery-qrcode.min.js"></script>
     <script src="jquery.storage.js/jquery.storage.js"></script>
     <script type="text/javascript">
         function escape_string (string) {
@@ -199,7 +199,11 @@
             }
             qrstring += ';';
             $('#qrcode').empty();
-            $('#qrcode').qrcode(qrstring);
+            $('#qrcode').qrcode({
+                text: qrstring,
+                quiet: 1,
+                background: '#FFF',
+            });
             $('#showssid').text('SSID: '+ssid);
             $('#save').show();
             $('#print').css('display', 'inline-block');


### PR DESCRIPTION
Many image viewers show black borders around the qr code making scanning
hard with some scanners.

I had to upgrade the jquery-qrcode dependency for being able to use this
feature. This requires a `git submodule sync --recursive` locally for
existing repositories since the remote url changed.