### PR TITLE
Use monospaced font when printing

### DIFF
--- a/print.css
+++ b/print.css
@@ -13,5 +13,6 @@
 #showssid,
 #showkey {
     display: block;
-    word-wrap: break-word; 
+    word-wrap: break-word;
+    font-family: Consolas, Menlo, "DejaVu Sans Mono", monospace;
 }


### PR DESCRIPTION
Reasoning behind the choice of fonts:

- All fonts somehow make a clear differentiation between the commonly confused letters `!IilL1oO0Q`
- `Consolas` - included by default since Windows Vista ([ref](https://en.wikipedia.org/wiki/Consolas))
- `Menlo` - the default mono font on Mac OS 10.11+ ([ref](https://en.wikipedia.org/wiki/Menlo_(typeface)))
- `DejaVu Sans Mono` - commonly installed in linux desktops ([ref](https://en.wikipedia.org/wiki/DejaVu_fonts)) and anecdotally it's on my windows 10 pc
- `monospace` will use whatever is the default monospace font.

One improvement would be to do only the actual password as monospace but at that point I'd be modifying javascript and I always try to do the minimum modifications to implement whatever it is I wanted to solve.

Will also fix #19