### PR TITLE
Scale the canvas without anti-aliasing enabled.

### DIFF
--- a/style.css
+++ b/style.css
@@ -43,6 +43,7 @@
 
 #qrcode canvas {
     padding: 2em;
+    image-rendering: crisp-edges;
 }
 
 .footer {


### PR DESCRIPTION
Anti-aliasing introduces grey pixels which aren't helpful in a QR code which consists exclusively of horizontal and vertical edges.